### PR TITLE
ISSUE-56: Add upload features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL:=/bin/bash
 VENV = venv
 PACKAGE = smart_canvas
 INT_PATH = bin
@@ -6,6 +7,7 @@ ifeq ($(OS), Windows_NT)
 endif
 PYTHON = $(VENV)/$(INT_PATH)/python
 PIP = $(VENV)/$(INT_PATH)/pip
+TOKEN = $(shell $(PYTHON) -c 'import uuid; print(uuid.uuid1())')
 
 $(VENV)/$(INT_PATH)/activate:
 	python -m venv venv
@@ -20,14 +22,18 @@ run: init
 
 .PHONY: web
 web: init
-	export FLASK_APP=web; $(PYTHON) -m flask run
+	export FLASK_APP=web; \
+	export CLIENT_TOKEN=$(TOKEN); \
+	$(PYTHON) -m flask run
 
 .PHONY: web-local
 web-local: init
+	export CLIENT_TOKEN=$(TOKEN); \
 	gunicorn --worker-class eventlet -w 1 'web:create_app()'
 
 .PHONY: hl
 hl: init
+	export CLIENT_TOKEN=$(TOKEN); \
 	heroku local
 
 .PHONY: test
@@ -40,11 +46,11 @@ test-w-warnings: init
 
 .PHONY: test-cov
 test-cov: init
-	$(PYTHON) -m pytest --cov=$(PACKAGE) --cov-report=term-missing -v
+	$(PYTHON) -m pytest --cov=$(PACKAGE) --cov="web" --cov-report=term-missing -v
 
 .PHONY: lint
 lint: init
-	$(PYTHON) -m pylint $(PACKAGE) tests
+	$(PYTHON) -m pylint $(PACKAGE) tests web
 
 .PHONY: clean
 clean:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'pytest==5.4.2',
         'pytest-cov==2.8.0',
         'pyparsing<3,>==2.0.2',
+        'autopep8==1.6.0',
         # render
         'moderngl==5.6.4',
         'moderngl-window==2.4.0',
@@ -33,7 +34,9 @@ setup(
         'Flask-SocketIO==5.1.1',
         'gunicorn==20.1.0',
         'eventlet==0.30.2',
+        'Werkzeug==2.0.2',
+        'Flask-APScheduler==1.12.2',
+        'Flask-HTTPAuth==4.5.0',
     ],
     setup_requires=['wheel']
-    
 )

--- a/tests/web_service_test.py
+++ b/tests/web_service_test.py
@@ -1,6 +1,9 @@
 """ web_service_test.py """
 
 import json
+import os
+from io import BytesIO
+from tempfile import mkdtemp
 
 import pytest
 
@@ -12,13 +15,146 @@ def client():
     '''
     based on http://flask.pocoo.org/docs/1.0/testing/
     '''
+    os.environ['CLIENT_TOKEN'] = 'test-token-ea520c84'
     app = create_app()
     yield app.test_client()
 
 
 class TestIndex(object):
     RESOURCE_URL = "/"
+
     def test_get(self, client):
         resp = client.get(self.RESOURCE_URL)
         assert resp.status_code == 200
         assert resp.data is not None
+
+
+class TestFileUpload(object):
+    RESOURCE_URL = "/upload"
+
+    def test_get(self, client):
+        # Fail without token
+        resp = client.get(self.RESOURCE_URL)
+        assert resp.status_code == 405
+        # Fail with token
+        resp = client.get(
+            self.RESOURCE_URL,
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'}
+        )
+        assert resp.status_code == 405
+
+    def test_post(self, client):
+        # Fail without token
+        contents = b'test-file-contents'
+        data = dict(file=(BytesIO(contents), 'test-1.jpeg'))
+        resp = client.post(
+            self.RESOURCE_URL,
+            data=data,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 401
+        # Fail with wrong token
+        data = dict(file=(BytesIO(contents), 'test-2.jpeg'))
+        resp = client.post(
+            self.RESOURCE_URL,
+            data=data,
+            content_type='multipart/form-data',
+            headers={'Authorization': f'Bearer wrong-token-123'}
+        )
+        assert resp.status_code == 401
+        # Succeed with valid token
+        data = dict(file=(BytesIO(contents), 'test-3.jpeg'))
+        resp = client.post(
+            self.RESOURCE_URL,
+            data=data,
+            content_type='multipart/form-data',
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'}
+        )
+        assert resp.status_code == 201
+
+
+class TestFileDownload(object):
+    RESOURCE_URL = "/uploads"
+    UPLOAD_URL = "/upload"
+
+    def test_get(self, client):
+        contents = b'test-file-contents'
+        # Put valid file into the system
+        data = dict(file=(BytesIO(contents), 'valid-file.jpeg'))
+        resp = client.post(
+            self.UPLOAD_URL,
+            data=data,
+            content_type='multipart/form-data',
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'}
+        )
+        picture_url = resp.data.decode("utf-8")
+        picture_name = picture_url.split("/")[-1]
+        # Succeed with token, valid picture
+        resp = client.get(
+            f'{self.RESOURCE_URL}/{picture_name}',
+            follow_redirects=True,
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'}
+        )
+        assert resp.status_code == 200
+        assert resp.data == contents
+        # Fail without token, valid picture
+        resp = client.get(
+            f'{self.RESOURCE_URL}/{picture_name}',
+            follow_redirects=True
+        )
+        assert resp.status_code == 401
+        # Fail without token, invalid picture
+        resp = client.get(
+            f'{self.RESOURCE_URL}/not-going-to-work.jpeg',
+            follow_redirects=True
+        )
+        assert resp.status_code == 401
+        # Fail with token, invalid picture
+        resp = client.get(
+            f'{self.RESOURCE_URL}/not-going-to-work.jpeg',
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'},
+            follow_redirects=True
+        )
+        assert resp.status_code == 404
+
+    def test_post(self, client):
+        contents = b'test-file-contents'
+        # Put valid file into the system
+        data = dict(file=(BytesIO(contents), 'valid-file.jpeg'))
+        resp = client.post(
+            self.UPLOAD_URL,
+            data=data,
+            content_type='multipart/form-data',
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'},
+        )
+        picture_url = resp.data.decode("utf-8")
+        picture_name = picture_url.split("/")[-1]
+        # Fail with real picture, valid picture
+        data = dict(file=(BytesIO(contents), picture_name))
+        resp = client.post(
+            resp.data,
+            follow_redirects=True,
+            data=data,
+            content_type='multipart/form-data',
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'}
+        )
+        assert resp.status_code == 405
+        # Fail without token, invalid picture
+        data = dict(file=(BytesIO(contents), 'test-1.jpeg'))
+        resp = client.post(
+            f'{self.RESOURCE_URL}/not-going-to-work.jpeg',
+            follow_redirects=True,
+            data=data,
+            content_type='multipart/form-data'
+        )
+        assert resp.status_code == 405
+        # Fail with token, invalid picture
+        data = dict(file=(BytesIO(contents), 'test-2.jpeg'))
+        resp = client.post(
+            f'{self.RESOURCE_URL}/not-going-to-work.jpeg',
+            follow_redirects=True,
+            data=data,
+            content_type='multipart/form-data',
+            headers={'Authorization': f'Bearer {os.getenv("CLIENT_TOKEN")}'}
+        )
+        assert resp.status_code == 405

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,17 +1,74 @@
 """ __init__.py """
 
+import sys
+import os
+import atexit
+import time
+from tempfile import mkdtemp
+
 from flask import Flask, render_template
 from flask_socketio import SocketIO
+from flask_apscheduler import APScheduler
 
 socketio = SocketIO(cors_allowed_origins="*")
 
-def create_app(debug=False):
-    """Create an application."""
+
+def create_app(test_config=None):
+    """
+    Based on http://flask.pocoo.org/docs/1.0/tutorial/factory/#the-application-factory
+    """
+    if os.getenv('CLIENT_TOKEN') is None:
+        sys.exit("environment variable CLIENT_TOKEN must be set!")
+
     app = Flask(__name__)
-    app.debug = debug
+    app.config.from_mapping(
+        SCHEDULER_API_ENABLED=True,
+        UPLOAD_FOLDER=mkdtemp('_web_service_uploads'),
+        TOKENS={
+            os.getenv('CLIENT_TOKEN'): "Client-1",
+        }
+    )
+
+    if test_config is not None:
+        app.config.from_mapping(test_config)
+
+    def get_old_files(age=5, files_path=app.config["UPLOAD_FOLDER"]):
+        """
+        age: age of the file, time in minutes.
+        file_path: file path
+        old_files: list of file paths
+        """
+        old_files = []
+        now = time.time()
+        for filename in os.listdir(files_path):
+            file_path = os.path.join(files_path, filename)
+            filestamp = os.stat(file_path).st_mtime
+            threshold = time.time() - (age * 60)
+            if filestamp < threshold:
+                old_files += [file_path]
+        return old_files
+
+    def rm_old_files(age=5, files_path=app.config["UPLOAD_FOLDER"]):
+        old_files = get_old_files(age=age, files_path=files_path)
+        for file in old_files:
+            os.remove(file)
+        return
+
+    scheduler = APScheduler()
+    scheduler.api_enabled = True
+    scheduler.init_app(app)
+    scheduler.add_job('cleaner', func=rm_old_files,
+                      trigger="interval", seconds=30)
+    scheduler.start()
+
+    atexit.register(lambda: scheduler.shutdown())
+    atexit.register(lambda: os.rmdir(app.config["UPLOAD_FOLDER"]))
+    atexit.register(lambda: rm_old_files(
+        age=0, files_path=app.config["UPLOAD_FOLDER"]))
 
     from .main import main as main_blueprint
     app.register_blueprint(main_blueprint)
 
     socketio.init_app(app)
+
     return app

--- a/web/main/routes.py
+++ b/web/main/routes.py
@@ -1,8 +1,63 @@
-from flask import render_template
+""" routes.py """
+
+import os
+from uuid import uuid4
+
+from flask import Response, render_template, flash, request, redirect, url_for, send_from_directory, current_app
+from flask_httpauth import HTTPTokenAuth
+from werkzeug.utils import secure_filename
+
 from . import main
+
+
+auth = HTTPTokenAuth(scheme='Bearer')
+
+
+@auth.verify_token
+def verify_token(token):
+    tokens = current_app.config["TOKENS"]
+    if token in tokens:
+        return tokens[token]
 
 
 @main.route('/')
 def index():
-    """Home page."""
+    """ Home page """
     return render_template('index.html')
+
+
+@main.route('/upload', methods=['POST'])
+@auth.login_required
+def upload_file():
+    """
+    https://flask.palletsprojects.com/en/2.0.x/patterns/fileuploads/
+    """
+    def allowed_file(filename):
+        ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
+        return '.' in filename and \
+            filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+    # check if the post request has the file part
+    if 'file' not in request.files:
+        flash('No file part')
+        return redirect(request.url)
+    file = request.files['file']
+    # If the user does not select a file, the browser submits an
+    # empty file without a filename.
+    if file.filename == '':
+        flash('No selected file')
+        return redirect(request.url)
+    if file and allowed_file(file.filename):
+        filename = secure_filename(f'{uuid4()}_{file.filename}')
+        file.save(os.path.join(
+            current_app.config['UPLOAD_FOLDER'], filename))
+        return Response(url_for('main.download_file', name=filename), status=201)
+
+
+@main.route('/uploads/<name>', methods=['GET'])
+@auth.login_required
+def download_file(name):
+    """
+    https://flask.palletsprojects.com/en/2.0.x/patterns/fileuploads/
+    """
+    return send_from_directory(current_app.config['UPLOAD_FOLDER'], name)


### PR DESCRIPTION
Added web folder to the coverage test
Added web folder to the linter targets
Added routes:
    /upload [POST]
    /uploads/{picture-name} [GET]

Authentication to these routes happen with predefined token.
Client has to set authorization header like so: `Authorization: Bearer {token-here}`
Not a hard coded one! The token has to be set in the environment variables before runtime.
For development usage, there is one set in the Makefile and in the pytests.

Give it a go and see what you think! :100: 