### PR TITLE
ISSUE-56: Don't use the APScheduler api

### DIFF
--- a/tests/web_service_test.py
+++ b/tests/web_service_test.py
@@ -166,3 +166,18 @@ class TestFileDownload(object):
             headers={'Authorization': f'Bearer {TOKEN}'}
         )
         assert resp.status_code == 405
+
+
+class TestAPSchedulerAPI(object):
+    RESOURCE_URL = "/scheduler"
+
+    def test_scheduler_info(self, client):
+        # Fail without token
+        resp = client.get(self.RESOURCE_URL)
+        assert resp.status_code == 404
+        # Fail with token
+        resp = client.get(
+            self.RESOURCE_URL,
+            headers={'Authorization': f'Bearer {TOKEN}'}
+        )
+        assert resp.status_code == 404

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -63,7 +63,7 @@ def create_app(test_config=None):
         return
 
     scheduler = APScheduler()
-    scheduler.api_enabled = True
+    scheduler.api_enabled = False
     scheduler.init_app(app)
     scheduler.add_job('cleaner', func=rm_old_files,
                       trigger="interval", seconds=30)

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -19,7 +19,7 @@ def create_app(test_config=None):
     """
     app = Flask(__name__)
     config = {
-        "SCHEDULER_API_ENABLED": True,
+        "SCHEDULER_API_ENABLED": False,
         "UPLOAD_FOLDER": mkdtemp('_web_service_uploads'),
         "TOKENS": dict(),
     }
@@ -63,7 +63,6 @@ def create_app(test_config=None):
         return
 
     scheduler = APScheduler()
-    scheduler.api_enabled = False
     scheduler.init_app(app)
     scheduler.add_job('cleaner', func=rm_old_files,
                       trigger="interval", seconds=30)


### PR DESCRIPTION
This opens an endpoint /scheduler on our web-service.
Therefore, set api => false

:worried: :worried: https://uni-smartcanvas.herokuapp.com/scheduler :worried: :worried: 